### PR TITLE
bff の codegen に enumAsTypesオプションを設定

### DIFF
--- a/bff/codegen.ts
+++ b/bff/codegen.ts
@@ -6,6 +6,7 @@ const config: CodegenConfig = {
     './src/generated/resolvers-types.ts': {
       config: {
         useIndexSignature: true,
+        enumsAsTypes: true,
       },
       plugins: ['typescript', 'typescript-resolvers'],
     },


### PR DESCRIPTION
コード生成でenumを使わないように